### PR TITLE
Add Seccomp to Linux Sandbox

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [linux-latest, windows-latest, macOS-latest]
+        os: [linux-latest, windows-latest]
+        # os: [linux-latest, windows-latest, macOS-latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Rust Build
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [linux-latest, windows-latest]
+        os: [linux-latest]
         # os: [linux-latest, windows-latest, macOS-latest]
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ version = "0.1.0"
 dependencies = [
  "landlock",
  "lddtree",
+ "libseccomp",
  "nix",
  "tempfile",
  "which",
@@ -145,6 +146,24 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libseccomp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5310a2c5b6ffbc094b5f70a2ca7b79ed36ad90e6f90994b166489a1bce3fcc"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libseccomp-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libseccomp-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60276e2d41bbb68b323e566047a1bfbf952050b157d8b5cdc74c07c1bf4ca3b6"
 
 [[package]]
 name = "linux-raw-sys"
@@ -184,6 +203,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,20 @@ which = "8.0.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4.4"
 lddtree = "0.4.0"
-nix = { version = "0.31.1", features = ["process", "signal", "fs", "feature"] }
+libseccomp = "0.4.0"
+nix = { version = "0.31.1", features = [
+    "process", "signal", "fs", "feature", "resource",
+    "user",
+] }
+
+# libseccomp documentation includes the note:
+# > if you want to use the libseccomp crate against musl-libc with statically
+# > linked the libseccomp library, you have to set the LIBSECCOMP_LINK_TYPE
+# > and LIBSECCOMP_LIB_PATH environment variables as follows.
+# > ```
+# > $ export LIBSECCOMP_LINK_TYPE=static
+# > $ export LIBSECCOMP_LIB_PATH="the path of the directory containing libseccomp.a (e.g. /usr/lib)"
+# > ```
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ DEBUG_TARGET := target/debug/libgrackle_zero.d
 SRC_FILES := $(shell find src -name '*.rs')
 
 
+build: test 
 
-build: test $(DEBUG_TARGET)
+clean: .FORCE
+	$(CARGO) clean
+	$(MAKE) -C tests clean
 
 test: test-bin .FORCE
 	$(CARGO) test
@@ -17,6 +20,15 @@ test-bin: .FORCE
 
 $(DEBUG_TARGET): $(SRC_FILES)
 	$(CARGO) build
+
+build-default: $(DEBUG_TARGET)
+
+build-linux: .FORCE
+	cargo build --target x86_64-unknown-linux-gnu
+
+build-win: .FORCE
+	# If running from Linux, this requires installing mingw-w64-gcc
+	cargo build --target x86_64-pc-windows-gnu
 
 
 .FORCE:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ The `stdin` and `stdout` communication should work with passing packets.  Things
 
 The `comm` sub-module offers some basic building blocks to extract packets out of streams.
 
+## Roadmap
+
+### Linux
+
+* [x] Implement execution.
+* [x] Clamp down on filesystem read and write access, as well as some limited network restrictions, using Landlock.
+* [x] Restrict the kinds of OS syscalls that can be made through SecComp.
+* [ ] Add resource restrictions like cgroups and CPU scheduling.
+* [ ] Add defense in depth by adding namespace mounts.
+
+### Windows
+
+* [ ] Implement execution.
+* [ ] Launch the process inside an AppContainer.
+
+### MacOS
+
+Last on the OS support list.
+
+* [ ] Implement execution.
+* [ ] Add a "deny by default" seatbelt profile.
+
 ## License
 
 Grackle Zero is under the [MIT License](LICENSE).

--- a/src/integration_tests/executables.rs
+++ b/src/integration_tests/executables.rs
@@ -79,7 +79,9 @@ fn cpuid() {
             cmd: util::find_exec("cpuid"),
 
             // This can pass in many different arguments.
-            args: util::str_as_args("soumicdhq"),
+            // Explicitly leaving out 'o', because that's easy to find out
+            // without any special privileges.
+            args: util::str_as_args("sumicdhq"),
             cwd: PathBuf::from("."),
             env: util::env_backtrace(),
             fds: util::std_fd(),

--- a/src/integration_tests/state.rs
+++ b/src/integration_tests/state.rs
@@ -50,7 +50,7 @@ impl Expected {
     /// the sending "completed" status.
     pub fn blocked() -> Self {
         Self {
-            exit_code: vec![101], // Seems like the standard Rust exit code for panic.
+            exit_code: vec![101, 111], // Seems like the standard Rust exit code for panic.
             handle_started: true,
             sent_init: true,
             read_start: true,

--- a/src/integration_tests/state.rs
+++ b/src/integration_tests/state.rs
@@ -199,7 +199,16 @@ impl InnerExecutionState {
                             success = false;
                         }
                     }
-                    Err(_) => (),
+                    Err(e) => {
+                        if expected.exit_code.contains(&0) {
+                            println!(
+                                "Expected success exit code, but runtime returned error: {:?}",
+                                e,
+                            );
+                            success = false;
+                        }
+                    },
+                    
                 }
             }
             None => {
@@ -209,6 +218,12 @@ impl InnerExecutionState {
                 let zero = 0i32;
                 if !expected.exit_code.contains(&zero) {
                     println!("Error: Child failed to terminate through the execution handler.");
+                    success = false;
+                } else if res.is_err() {
+                    println!(
+                        "Expected success exit code, but runtime returned error: {:?}",
+                        res.err().unwrap(),
+                    );
                     success = false;
                 }
             }

--- a/src/integration_tests/util.rs
+++ b/src/integration_tests/util.rs
@@ -75,11 +75,6 @@ pub fn find_exec(exec_name: &str) -> PathBuf {
     exec
 }
 
-/// Create an empty environment set.
-pub fn no_env() -> HashMap<OsString, OsString> {
-    HashMap::new()
-}
-
 /// Create an environment that tells the executed rust program to include the backtrace.
 pub fn env_backtrace() -> HashMap<OsString, OsString> {
     let mut env = HashMap::new();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -27,7 +27,7 @@ pub fn sandbox_child<CH: CommHandler>(
     let child = spawn_linux::launch_child(env)?;
     let state = child.state();
     handler.handle(Box::new(child))?;
-    state.child_exit_code()
+    state.kill().map_err(|e| e.into())
 }
 
 #[cfg(target_os = "windows")]

--- a/src/runtime/spawn_darwin.rs
+++ b/src/runtime/spawn_darwin.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-/// Specific to Darwin (macOS).
-/// Will use the sandbox-exec feature.
-/// 
-/// Inspiration pulled from https://github.com/agentic-dev3o/sandbox-shell
-/// (under the MIT license).
+//! Specific to Darwin (macOS).
+//! Will use the sandbox-exec feature.
+//!
+//! Inspiration pulled from https://github.com/agentic-dev3o/sandbox-shell
+//! (under the MIT license).

--- a/src/runtime/spawn_linux.rs
+++ b/src/runtime/spawn_linux.rs
@@ -3,6 +3,7 @@
 //! Spawns the process with proper security restrictions.
 //! Specific to Linux.  Uses Landlock for jail restrictions.
 
+mod call_names;
 mod dependencies;
 mod fd;
 mod jail;

--- a/src/runtime/spawn_linux/call_names.rs
+++ b/src/runtime/spawn_linux/call_names.rs
@@ -1,0 +1,78 @@
+//! List of syscall names to used in the filters.
+//! 
+//! This allows for a larger than minimal set of privileges because the executable
+//! will generally need access to load dynamic libraries and perform some
+//! basic thread setup, even if it doesn't use threads.
+
+pub(crate) const ALLOW_LIST: &[&str] = &[
+    "read",
+    "write",
+    "readv",
+    "writev",
+    "close",
+    "pread64",
+    "pwrite64",
+    "access",
+    "faccessat",
+    "faccessat2",
+    "fcntl",
+    "lseek",
+    "exit",
+    "exit_group",
+    "brk",
+    "mmap",
+    "mprotect",
+    "mremap",
+    "munmap",
+    "madvise",
+    "rt_sigaction",
+    "rt_sigprocmask",
+    "rt_sigreturn",
+    "sigaltstack",
+    "arch_prctl",
+    "set_tid_address",
+    "set_robust_list",
+    "futex",
+    "rseq",
+    "getpid",
+    "gettid",
+    "getrandom",
+    "fstat",
+    "fstatat",
+    "newfstatat",
+    "prlimit64",
+    "poll",
+
+    // Rely on FD inheritance and FD closures before exec to add restrictions that this would otherwise let pass.
+    "ioctl",
+
+    // Some code uses threads, or sets up threads even if not used.
+    "set_tid_address",
+    "set_robust_list",
+    "futex",
+    "rseq",
+    "rt_sigreturn",
+
+    // Allow the command execution to happen.
+    "execve",
+
+    // For lazy loaded libraries, some limited use of openat is allowed.
+    // This should be a conditional, but I can't figure out the right semantics
+    // to get it to run.  Instead, we rely on landlock to prevent bad opens.
+    "open",
+    "openat",
+    "openat2",
+        //.add_rule_conditional(
+        //    ScmpAction::Allow,
+        //    ScmpSyscall::from_name("openat")?,
+        //    &[
+        //        // Only allow the access mode, not the creation flags.
+        //        scmp_cmp!($arg0 & ((
+        //            nix::libc::O_ACCMODE | nix::libc::O_CREAT | nix::libc::O_TRUNC | nix::libc::O_TMPFILE | nix::libc::O_APPEND
+        //        ) as u64) == nix::libc::O_RDONLY as u64),
+        //    ])?
+
+    // Should prevent timers where possible, to prevent rowhammer and spectre and meltdown attacks.
+    // "timer_create",
+    // "clock_gettime",
+];

--- a/src/runtime/spawn_linux/fd.rs
+++ b/src/runtime/spawn_linux/fd.rs
@@ -300,6 +300,7 @@ mod tests {
                 let mut f = unsafe { File::from_raw_fd(17) };
                 exit_on_err(f.write_all(&buf));
                 exit_on_err(f.flush());
+                drop(f);  // because of the "read_to_end", need to close the FD.
 
                 // Read from fd 21.
                 let mut f = unsafe { File::from_raw_fd(21) };

--- a/src/runtime/spawn_linux/launch.rs
+++ b/src/runtime/spawn_linux/launch.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     ffi::CString,
     os::unix::ffi::OsStrExt as _,
-    path::PathBuf,
+    path::PathBuf, sync::{Arc, Mutex},
 };
 
 use nix::sys::wait::WaitStatus;
@@ -22,13 +22,13 @@ use crate::runtime::{
 };
 
 pub struct LinuxChild {
-    pid: nix::unistd::Pid,
+    state: LinuxChildState,
     fds: HashMap<u32, FdMap>,
 }
 
 impl LinuxChild {
     pub(crate) fn state(&self) -> LinuxChildState {
-        LinuxChildState { pid: self.pid }
+        self.state.clone()
     }
 }
 
@@ -48,7 +48,14 @@ pub fn launch_child(env: LaunchEnv) -> Result<LinuxChild, SandboxError> {
     let exec_path = exec_path.as_c_str();
     let cwd = CString::new(env.cwd.as_os_str().as_bytes())?;
     let cwd = cwd.as_c_str();
-    let mut args = Vec::new();
+    let mut args = vec![
+        // This is interesting.  Because the first argument is the
+        // executable, and this is controlling all the aspects for setting
+        // up the program, we need to construct the first argument here as
+        // the executable name.  In order to avoid leaking information, this
+        // constructs a hard-coded executable name.
+        CString::new("sandboxed")?,
+    ];
     for arg in env.args {
         args.push(CString::new(arg.as_os_str().as_bytes())?);
     }
@@ -92,7 +99,7 @@ pub fn launch_child(env: LaunchEnv) -> Result<LinuxChild, SandboxError> {
         Ok(nix::unistd::ForkResult::Parent { child }) => {
             let fds = fd_set.parent_after_fork();
             Ok(LinuxChild {
-                pid: child,
+                state: LinuxChildState::new(child),
                 fds: fd_map(fds),
             })
         }
@@ -101,9 +108,8 @@ pub fn launch_child(env: LaunchEnv) -> Result<LinuxChild, SandboxError> {
 
 impl Child for LinuxChild {
     fn terminate(&self) -> Result<(), std::io::Error> {
-        // The child cannot listen to signals, so kill it hard.
-        nix::sys::signal::kill(self.pid, nix::sys::signal::Signal::SIGKILL)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        self.state.kill()
+            .and(Ok(()))
     }
 
     fn take_stream_from_child(&mut self, fd: u32) -> Option<Box<dyn std::io::Read>> {
@@ -127,20 +133,7 @@ impl Child for LinuxChild {
     }
 
     fn exit_status(&self) -> Option<i32> {
-        match nix::sys::wait::waitpid(
-            self.pid,
-            nix::sys::wait::WaitPidFlag::from_bits(nix::libc::WNOHANG),
-        ) {
-            // An error usually means that the child never started.
-            Err(_) => None,
-            Ok(WaitStatus::Exited(_pid, c)) => Some(c),
-            Ok(WaitStatus::StillAlive) => None,
-            Ok(WaitStatus::Signaled(_, _, _)) => None,
-            Ok(WaitStatus::Stopped(_, _)) => None,
-            Ok(WaitStatus::PtraceEvent(_, _, _)) => None,
-            Ok(WaitStatus::PtraceSyscall(_)) => None,
-            Ok(WaitStatus::Continued(_)) => None,
-        }
+        self.state.exit_code()
     }
 }
 
@@ -210,32 +203,105 @@ fn close_open_fds(except: &HashSet<nix::libc::c_int>) {
 
 /// Structure that allows querying the state of a launched Linux child process,
 /// outside the CallHandler use.
+#[derive(Clone)]
 pub(crate) struct LinuxChildState {
     pid: nix::unistd::Pid,
+    killed: Arc<Mutex<bool>>,
+    exit_code: Arc<Mutex<Option<i32>>>,
 }
 
 impl LinuxChildState {
-    pub(crate) fn child_exit_code(&self) -> Result<i32, SandboxError> {
+    pub(crate) fn new(pid: nix::unistd::Pid) -> Self {
+        LinuxChildState {
+            pid,
+            killed: Arc::new(Mutex::new(false)),
+            exit_code: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(crate) fn exit_code(&self) -> Option<i32> {
+        let mut c = match self.exit_code.lock() {
+            Ok(guard) => guard,
+            Err(_) => return None,
+        };
+        match *c {
+            Some(code) => Some(code),
+            None => {
+                // FIXME if c is None, then perform a wait-pid.
+                match nix::sys::wait::waitpid(
+                    self.pid,
+                    nix::sys::wait::WaitPidFlag::from_bits(nix::libc::WNOHANG),
+                ) {
+                    // An error usually means that the child never started.  However,
+                    // this should never receive a PID if that's the case.
+                    // It can also mean that this process doesn't have access, or some
+                    // very weird state.
+                    Err(_) => {
+                        None
+                    },
+                    Ok(WaitStatus::Exited(_pid, ec)) => {
+                        // What we expect.
+                        *c = Some(ec);
+                        Some(ec)
+                    },
+                    Ok(_) => {
+                        // Still alive
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn kill(&self) -> Result<i32, std::io::Error> {
+        let mut k = self.killed.lock()
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "lock poisoned"))?;
+        let mut ec = self.exit_code.lock()
+                .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "lock poisoned"))?;
+        if *k {
+            match *ec {
+                Some(c) => return Ok(c),
+                None => return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "BUG: process already killed, but exit code not set",
+                )),
+            }
+        }
+
+        // The child cannot listen to signals, so kill it hard.
+        nix::sys::signal::kill(self.pid, nix::sys::signal::Signal::SIGKILL)
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("failed terminating child {}: {:?}", self.pid, e),
+            ))?;
+
         match nix::sys::wait::waitpid(
             self.pid,
             nix::sys::wait::WaitPidFlag::from_bits(nix::libc::WNOHANG),
         ) {
-            // An error usually means that the child never started.
-            Err(r) => Err(SandboxError::ProcessError(r.to_string())),
-            Ok(WaitStatus::Exited(_pid, c)) => Ok(c),
-            Ok(_) => {
-                // Still alive, so need to kill it.
-                nix::sys::signal::kill(self.pid, nix::sys::signal::Signal::SIGKILL).map_err(
-                    |e| SandboxError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)),
-                )?;
-                // Call and wait for the termination this time.
-                match nix::sys::wait::waitpid(self.pid, None) {
-                    Err(r) => Err(SandboxError::ProcessError(r.to_string())),
-                    Ok(WaitStatus::Exited(_pid, c)) => Ok(c),
-                    Ok(_) => Err(SandboxError::ProcessError(
-                        "unexpected wait status after killing child".to_string(),
-                    )),
-                }
+            // An error usually means that the child never started.  However,
+            // this should never receive a PID if that's the case.
+            // It can also mean that this process doesn't have access, or some
+            // very weird state.
+            Err(r) => {
+                // Don't mark the process as killed.
+                // It might be an intermittent error?
+                Err(r.into())
+            },
+            Ok(WaitStatus::Exited(_pid, c)) => {
+                // What we expect.
+                *k = true;
+                *ec = Some(c);
+                Ok(c)
+            },
+            Ok(v) => {
+                // The kill didn't work, and the process is alive in some odd
+                // state.
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other, format!(
+                    "unexpected wait status after killing child: {:?}",
+                    v
+                )))
             }
         }
     }

--- a/src/runtime/spawn_win.rs
+++ b/src/runtime/spawn_win.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-/// Sandbox for Windows.
-/// 
-/// Inspired by the Chromium sandboxing model.
-/// Code:
-///   https://github.com/chromium/chromium/blob/main/sandbox
-///   under the BSD license.
-/// Documentation:
-///   https://github.com/chromium/chromium/blob/main/docs/design/sandbox.md
-///   https://github.com/chromium/chromium/blob/main/docs/design/sandbox_faq.md
+//! Sandbox for Windows.
+//!
+//! Inspired by the Chromium sandboxing model.
+//! Code:
+//!   https://github.com/chromium/chromium/blob/main/sandbox
+//!   under the BSD license.
+//! Documentation:
+//!   https://github.com/chromium/chromium/blob/main/docs/design/sandbox.md
+//!   https://github.com/chromium/chromium/blob/main/docs/design/sandbox_faq.md

--- a/src/runtime/spawn_windows.rs
+++ b/src/runtime/spawn_windows.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 //! Sandbox for Windows.
-//!
+//! 
 //! Inspired by the Chromium sandboxing model.
 //! Code:
 //!   https://github.com/chromium/chromium/blob/main/sandbox

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,5 +6,9 @@ all: $(SUBDIRS) .FORCE
 $(SUBDIRS): .FORCE
 	$(MAKE) -C $(@D)
 
+clean: .FORCE
+	for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir clean; \
+	done
 
 .FORCE:

--- a/tests/cpuid/src/action.rs
+++ b/tests/cpuid/src/action.rs
@@ -56,10 +56,10 @@ pub(crate) fn perform(action: String) {
 
 #[cfg(target_os = "linux")]
 /// Get the linux system identifier.
-/// Note that general approaches to this require reading files, which is
-/// tested to be prevented elsewhere.
 fn get_system_id() -> Result<String, String> {
-    Err("uses file access".to_string())
+    std::fs::read_to_string("/etc/machine-id")
+        .map(|s| s.trim().to_string())
+        .map_err(|e| format!("failed reading /etc/machine-id: {:?}", e))
 }
 
 #[cfg(target_os = "macos")]

--- a/tests/cpuid/src/action.rs
+++ b/tests/cpuid/src/action.rs
@@ -73,31 +73,31 @@ fn get_system_id() -> Result<String, String> {
 #[cfg(target_os = "windows")]
 mod u_windows {
     use winreg::{RegKey, enums::HKEY_LOCAL_MACHINE};
-    use wmi::{COMLibrary, WMIConnection};
-
-    thread_local! {
-        static COM_LIB:COMLibrary = COMLibrary::without_security().unwrap();
-    }
+    use wmi::WMIConnection;
 
     pub fn read_local_machine_reg(key: &str, value: &str) -> Result<String, String> {
         use winreg::enums::{KEY_READ, KEY_WOW64_64KEY};
 
         let r_key = RegKey::predef(HKEY_LOCAL_MACHINE)
-            .open_subkey_with_flags(key, KEY_READ | KEY_WOW64_64KEY)?;
+            .open_subkey_with_flags(key, KEY_READ | KEY_WOW64_64KEY)
+            .map_err(|e| format!("failed reading {}: {:?}", key, e))?;
 
-        let id = r_key.get_value(value)?;
+        let id = r_key.get_value(value)
+            .map_err(|e| format!("failed reading {}/{}: {:?}", key, value, e))?;
         Ok(id)
     }
 
-    pub fn wmi_query(query: &str) -> Result<String, String> {
-        let con = WMIConnection::new(COM_LIB.with(|con| *con))?;
-        con.raw_query(query)?;
+    pub fn wmi_query(query: &str) -> Result<Vec<String>, String> {
+        let con = WMIConnection::new()
+            .map_err(|e| format!("failed getting WMI connection: {:?}", e))?;
+        con.raw_query(query)
+            .map_err(|e| format!("failed running WMI query: {:?}", e))
     }
 }
 
 #[cfg(target_os = "windows")]
 fn get_system_id() -> Result<String, String> {
-    u_windows.read_local_machine_reg("SOFTWARE\\Microsoft\\Cryptography", "MachineGuid")
+    u_windows::read_local_machine_reg("SOFTWARE\\Microsoft\\Cryptography", "MachineGuid")
 }
 
 fn get_os_name() -> Result<String, String> {
@@ -137,7 +137,11 @@ fn get_cpu_id() -> Result<String, String> {
 
 #[cfg(target_os = "windows")]
 fn get_drive_serial() -> Result<String, String> {
-    u_windows::wmi_query("SELECT SerialNumber FROM Win32_PhysicalMedia")
+    match u_windows::wmi_query("SELECT SerialNumber FROM Win32_PhysicalMedia")?
+        .get(0) {
+        Some(v) => Ok(v.clone()),
+        None => Err("no serial number found".to_string()),
+    }
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/tests/cpuid/src/main.rs
+++ b/tests/cpuid/src/main.rs
@@ -6,7 +6,7 @@ mod debug;
 use std::io::{Read, Write};
 
 fn main() {
-    let arg = std::env::args().nth(0).unwrap();
+    let arg = std::env::args().nth(1).unwrap();
     debug::debug(format!("started [{}] [{}]", file!(), arg));
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();

--- a/tests/exec-self/src/main.rs
+++ b/tests/exec-self/src/main.rs
@@ -6,7 +6,7 @@ mod debug;
 use std::io::{Read, Write};
 
 fn main() {
-    let arg = std::env::args().nth(0).unwrap();
+    let arg = std::env::args().nth(1).unwrap();
     debug::debug(format!("started [{}] [{}]", file!(), arg));
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();

--- a/tests/file-read/src/main.rs
+++ b/tests/file-read/src/main.rs
@@ -6,7 +6,7 @@ mod debug;
 use std::io::{Read, Write};
 
 fn main() {
-    let arg = std::env::args().nth(0).unwrap();
+    let arg = std::env::args().nth(1).unwrap();
     debug::debug(format!("started [{}] [{}]", file!(), arg));
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();

--- a/tests/noop/src/main.rs
+++ b/tests/noop/src/main.rs
@@ -6,7 +6,7 @@ mod debug;
 use std::io::{Read, Write};
 
 fn main() {
-    let arg = std::env::args().nth(0).unwrap();
+    let arg = std::env::args().nth(1).unwrap();
     debug::debug(format!("started [{}] [{}]", file!(), arg));
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();

--- a/tests/tcpip/src/main.rs
+++ b/tests/tcpip/src/main.rs
@@ -6,7 +6,7 @@ mod debug;
 use std::io::{Read, Write};
 
 fn main() {
-    let arg = std::env::args().nth(0).unwrap();
+    let arg = std::env::args().nth(1).unwrap();
     debug::debug(format!("started [{}] [{}]", file!(), arg));
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();


### PR DESCRIPTION
This adds seccomp support for the Linux sandbox, and adds a host of new bug fixes.

* Added seccomp clamping rules, to add additional sandbox protections for the spawned process.  This now significantly reduces the number of OS commands that the process can run.  There are, though, still a large number it can run to support the need for dynamic library loading.  However, combined with landlock, it reduces the number of files it can touch to just the executable and the declared shared libraries.
* Added an `rlimit` to limit the number of open file handles in the Linux processes.  At the moment, this is a hard-coded limit, but is expected to move to a configurable value.
* Fixed the Linux invocation of the executables where it did not give the executable as the first argument.
* Improved the Linux handling of child termination and detection.
* Better integration testing.